### PR TITLE
Fixed integer frequency to string, without using float

### DIFF
--- a/src/_txRx.ino
+++ b/src/_txRx.ino
@@ -654,7 +654,7 @@ int buildPacket(uint8_t *buff_up, struct LoraUp *LoraUp, bool internal)
 #else 
 // _JSONENCODE undefined, this is default
 // ---------------------------------------
-	ftoa((double)freqs[gwayConfig.ch].upFreq / 1000000, cfreq, 6);		// XXX This can be done better
+	__freqToCharMhz(freqs[gwayConfig.ch].upFreq, cfreq);
 	if ((LoraUp->sf<6) || (LoraUp->sf>12)) { 							// Lora datarate & bandwidth SF6-SF12, 16-19 useful chars */
 		LoraUp->sf=7;
 	}			

--- a/src/_utils.ino
+++ b/src/_utils.ino
@@ -322,8 +322,8 @@ int mStat(uint8_t intr, String & response)
 // ----------------------------------------------------------------------------
 void __freqToCharMhz(uint32_t freq, char *out) {
   itoa(freq, out, 10);
-  int i=10;
-  for (i = 10; i > 2; i--){
+
+  for (int i = 10; i > 2; i--){
     out[i] = out[i-1];
   }
   out[3] = '.';

--- a/src/_utils.ino
+++ b/src/_utils.ino
@@ -313,6 +313,21 @@ int mStat(uint8_t intr, String & response)
 
 // ============== NUMBER FUNCTIONS ============================================
 
+// ----------------------------------------------------------------------------
+// Convert the given LoRa frequency, in Hz, to Mhz in a string
+// It does not use float conversion, as float isnt accurate.
+// Parameters:
+//	freq is the freq to convert, from 100000000 to 999999999 Hz
+//	*out is the strinf buffer, minimum 11 chars.
+// ----------------------------------------------------------------------------
+void __freqToCharMhz(uint32_t freq, char *out) {
+  itoa(freq, out, 10);
+  int i=10;
+  for (i = 10; i > 2; i--){
+    out[i] = out[i-1];
+  }
+  out[3] = '.';
+}
 
 // ----------------------------------------------------------------------------
 // Convert a float to string for printing


### PR DESCRIPTION
I was getting a invalid frequency over the json sent. This is due to using float to convert the Hz integer to Mhz string to be sent out. But floats, even double precision, aren't accurate and it is not necessary to use it when you already has the full information in the integer and only needs to do fixed point conversion, as the float conversion can lead to approximations and loose the accuracy. Before i wasn't able to connect to chirpstack network server, but now it works fine.